### PR TITLE
Add link-local support

### DIFF
--- a/internal/ice/base.go
+++ b/internal/ice/base.go
@@ -42,7 +42,11 @@ func createBase(component int) (base Base, err error) {
 func getLocalIP() (net.IP, error) {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
-		return nil, err
+		// Try with link-local address
+		conn, err = net.Dial("udp", "169.254.1.1:80")
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
To determine the local IP address, ICE creates a UDP socket that
would be used to reach 8.8.8.8, although no traffic is actually
sent. However, if 8.8.8.8 is not routable via a network interface,
this approach fails. This matters when only a link-local interface
to a peer is available (i.e. an Ethernet cable, where wi-fi say is
not available, such as at the library, during testing, or a demo).

The solution is to use a similar test to an address in the
link-local subnet (i.e. 169.254.0.0/16). Only do this if first
test fails.