### PR TITLE
Progress toward IPv6 support (issue #26)

### DIFF
--- a/internal/ice/pair.go
+++ b/internal/ice/pair.go
@@ -36,7 +36,7 @@ func (state CandidatePairState) String() string {
 	case InProgress:
 		return "In Progress"
 	case Succeeded:
-		return "Succedeed"
+		return "Succeeded"
 	case Failed:
 		return "Failed"
 	default:


### PR DESCRIPTION
When running locally on my home network, I was able to create both IPv4 and IPv6 local candidates. ICE gives higher priority to IPv6, so most of the time that's what got selected, and everything seemed to work. However *sometimes*, the connection would be established but no video would play. I didn't have time to fully dig in to why that was, so for now I put IPv6 support behind the `-6` flag. When I get more time to debug I'll try to fix that problem.