### PR TITLE
Adds RTCP receiver report support

### DIFF
--- a/internal/rtcp/errors.go
+++ b/internal/rtcp/errors.go
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import "errors"
+
+var (
+	errInvalidTotalLost = errors.New("rtcp: invalid total lost count")
+	errInvalidHeader    = errors.New("rtcp: invalid header")
+	errTooManyReports   = errors.New("rtcp: too many reports")
+	errTooManyChunks    = errors.New("rtcp: too many chunks")
+	errTooManySources   = errors.New("rtcp: too many sources")
+	errPacketTooShort   = errors.New("rtcp: packet too short")
+	errWrongType        = errors.New("rtcp: wrong packet type")
+	errSDESTextTooLong  = errors.New("rtcp: sdes must be < 255 octets long")
+	errSDESMissingType  = errors.New("rtcp: sdes item missing type")
+	errReasonTooLong    = errors.New("rtcp: reason must be < 255 octets long")
+	errBadVersion       = errors.New("rtcp: invalid packet version")
+)

--- a/internal/rtcp/header.go
+++ b/internal/rtcp/header.go
@@ -1,0 +1,155 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import "encoding/binary"
+
+// PacketType specifies the type of an RTCP packet
+type PacketType uint8
+
+// RTCP packet types registered with IANA. See:https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-4
+const (
+	TypeSenderReport              PacketType = 200 // RFC 3550, 6.4.1
+	TypeReceiverReport            PacketType = 201 // RFC 3550, 6.4.2
+	TypeSourceDescription         PacketType = 202 // RFC 3550, 6.5
+	TypeGoodbye                   PacketType = 203 // RFC 3550, 6.6
+	TypeApplicationDefined        PacketType = 204 // RFC 3550, 6.7 (unimplemented)
+	TypeTransportSpecificFeedback PacketType = 205 // RFC 4585, 6051
+	TypePayloadSpecificFeedback   PacketType = 206 // RFC 4585, 6.3
+
+)
+
+// Transport and Payload specific feedback messages overload the count field to act as a message type. those are listed here
+const (
+	FormatSLI uint8 = 2
+	FormatPLI uint8 = 1
+	FormatTLN uint8 = 1
+	FormatRRR uint8 = 5
+)
+
+func (p PacketType) String() string {
+	switch p {
+	case TypeSenderReport:
+		return "SR"
+	case TypeReceiverReport:
+		return "RR"
+	case TypeSourceDescription:
+		return "SDES"
+	case TypeGoodbye:
+		return "BYE"
+	case TypeApplicationDefined:
+		return "APP"
+	case TypeTransportSpecificFeedback:
+		return "TSFB"
+	case TypePayloadSpecificFeedback:
+		return "PSFB"
+	default:
+		return string(p)
+	}
+}
+
+const rtpVersion = 2
+
+// A Header is the common header shared by all RTCP packets
+type Header struct {
+	// If the padding bit is set, this individual RTCP packet contains
+	// some additional padding octets at the end which are not part of
+	// the control information but are included in the length field.
+	Padding bool
+	// The number of reception reports, sources contained or FMT in this packet (depending on the Type)
+	Count uint8
+	// The RTCP packet type for this packet
+	Type PacketType
+	// The length of this RTCP packet in 32-bit words minus one,
+	// including the header and any padding.
+	Length uint16
+}
+
+const (
+	headerLength = 4
+	versionShift = 6
+	versionMask  = 0x3
+	paddingShift = 5
+	paddingMask  = 0x1
+	countShift   = 0
+	countMask    = 0x1f
+	countMax     = (1 << 5) - 1
+)
+
+// Marshal encodes the Header in binary
+func (h Header) Marshal() ([]byte, error) {
+	/*
+	 *  0                   1                   2                   3
+	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |V=2|P|    RC   |   PT=SR=200   |             length            |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 */
+	rawPacket := make([]byte, headerLength)
+
+	rawPacket[0] |= rtpVersion << versionShift
+
+	if h.Padding {
+		rawPacket[0] |= 1 << paddingShift
+	}
+
+	if h.Count > 31 {
+		return nil, errInvalidHeader
+	}
+	rawPacket[0] |= h.Count << countShift
+
+	rawPacket[1] = uint8(h.Type)
+
+	binary.BigEndian.PutUint16(rawPacket[2:], h.Length)
+
+	return rawPacket, nil
+}
+
+// Unmarshal decodes the Header from binary
+func (h *Header) Unmarshal(rawPacket []byte) error {
+	if len(rawPacket) < headerLength {
+		return errInvalidHeader
+	}
+
+	/*
+	 *  0                   1                   2                   3
+	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |V=2|P|    RC   |      PT       |             length            |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 */
+
+	version := rawPacket[0] >> versionShift & versionMask
+	if version != rtpVersion {
+		return errBadVersion
+	}
+
+	h.Padding = (rawPacket[0] >> paddingShift & paddingMask) > 0
+	h.Count = rawPacket[0] >> countShift & countMask
+
+	h.Type = PacketType(rawPacket[1])
+
+	h.Length = binary.BigEndian.Uint16(rawPacket[2:])
+
+	return nil
+}

--- a/internal/rtcp/header_test.go
+++ b/internal/rtcp/header_test.go
@@ -1,0 +1,135 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHeaderUnmarshal(t *testing.T) {
+	for _, test := range []struct {
+		Name      string
+		Data      []byte
+		Want      Header
+		WantError error
+	}{
+		{
+			Name: "valid",
+			Data: []byte{
+				// v=2, p=0, count=1, RR, len=7
+				0x81, 0xc9, 0x00, 0x07,
+			},
+			Want: Header{
+				Padding: false,
+				Count:   1,
+				Type:    TypeReceiverReport,
+				Length:  7,
+			},
+		},
+		{
+			Name: "also valid",
+			Data: []byte{
+				// v=2, p=1, count=1, BYE, len=7
+				0xa1, 0xcc, 0x00, 0x07,
+			},
+			Want: Header{
+				Padding: true,
+				Count:   1,
+				Type:    TypeApplicationDefined,
+				Length:  7,
+			},
+		},
+		{
+			Name: "bad version",
+			Data: []byte{
+				// v=0, p=0, count=0, RR, len=4
+				0x00, 0xc9, 0x00, 0x04,
+			},
+			WantError: errBadVersion,
+		},
+	} {
+		var h Header
+		err := h.Unmarshal(test.Data)
+		if got, want := err, test.WantError; got != want {
+			t.Fatalf("Unmarshal %q header: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		if got, want := h, test.Want; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Unmarshal %q header: got %v, want %v", test.Name, got, want)
+		}
+	}
+}
+func TestHeaderRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		Name      string
+		Header    Header
+		WantError error
+	}{
+		{
+			Name: "valid",
+			Header: Header{
+				Padding: true,
+				Count:   31,
+				Type:    TypeSenderReport,
+				Length:  4,
+			},
+		},
+		{
+			Name: "also valid",
+			Header: Header{
+				Padding: false,
+				Count:   28,
+				Type:    TypeReceiverReport,
+				Length:  65535,
+			},
+		},
+		{
+			Name: "invalid count",
+			Header: Header{
+				Count: 40,
+			},
+			WantError: errInvalidHeader,
+		},
+	} {
+		data, err := test.Header.Marshal()
+		if got, want := err, test.WantError; got != want {
+			t.Errorf("Marshal %q: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		var decoded Header
+		if err := decoded.Unmarshal(data); err != nil {
+			t.Errorf("Unmarshal %q: %v", test.Name, err)
+		}
+
+		if got, want := decoded, test.Header; !reflect.DeepEqual(got, want) {
+			t.Errorf("%q header round trip: got %#v, want %#v", test.Name, got, want)
+		}
+	}
+}

--- a/internal/rtcp/packet.go
+++ b/internal/rtcp/packet.go
@@ -1,0 +1,84 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+// Packet represents an RTCP packet, a protocol used for out-of-band statistics and control information for an RTP session
+type Packet interface {
+	Header() Header
+	// DestinationSSRC returns an array of SSRC values that this packet refers to.
+	DestinationSSRC() []uint32
+
+	Marshal() ([]byte, error)
+	Unmarshal(rawPacket []byte) error
+}
+
+// Unmarshal is a factory a polymorphic RTCP packet, and its header,
+func Unmarshal(rawPacket []byte) (Packet, Header, error) {
+	var h Header
+	var p Packet
+
+	err := h.Unmarshal(rawPacket)
+	if err != nil {
+		return nil, h, err
+	}
+
+	switch h.Type {
+	//	case TypeSenderReport:
+	//		p = new(SenderReport)
+
+	case TypeReceiverReport:
+		p = new(ReceiverReport)
+
+		//	case TypeSourceDescription:
+		//		p = new(SourceDescription)
+		//
+		//	case TypeGoodbye:
+		//		p = new(Goodbye)
+		//
+		//	case TypeTransportSpecificFeedback:
+		//		switch h.Count {
+		//		case FormatTLN:
+		//			p = new(TransportLayerNack)
+		//		case FormatRRR:
+		//			p = new(RapidResynchronizationRequest)
+		//		default:
+		//			p = new(RawPacket)
+		//		}
+		//
+		//	case TypePayloadSpecificFeedback:
+		//		switch h.Count {
+		//		case FormatPLI:
+		//			p = new(PictureLossIndication)
+		//		case FormatSLI:
+		//			p = new(SliceLossIndication)
+		//		default:
+		//			p = new(RawPacket)
+		//		}
+
+	default:
+		p = new(RawPacket)
+	}
+
+	err = p.Unmarshal(rawPacket)
+	return p, h, err
+}

--- a/internal/rtcp/raw_packet.go
+++ b/internal/rtcp/raw_packet.go
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+// RawPacket represents an unparsed RTCP packet. It's returned by Unmarshal when
+// a packet with an unknown type is encountered.
+type RawPacket []byte
+
+// Marshal encodes the packet in binary.
+func (r RawPacket) Marshal() ([]byte, error) {
+	return r, nil
+}
+
+// Unmarshal decodes the packet from binary.
+func (r *RawPacket) Unmarshal(b []byte) error {
+	if len(b) < (headerLength) {
+		return errPacketTooShort
+	}
+	*r = b
+
+	var h Header
+	return h.Unmarshal(b)
+}
+
+// Header returns the Header associated with this packet.
+func (r RawPacket) Header() Header {
+	var h Header
+	if err := h.Unmarshal(r); err != nil {
+		return Header{}
+	}
+	return h
+}
+
+// DestinationSSRC returns an array of SSRC values that this packet refers to.
+func (r *RawPacket) DestinationSSRC() []uint32 {
+	return []uint32{}
+}

--- a/internal/rtcp/raw_packet_test.go
+++ b/internal/rtcp/raw_packet_test.go
@@ -1,0 +1,83 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRawPacketRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		Name               string
+		Packet             RawPacket
+		WantMarshalError   error
+		WantUnmarshalError error
+	}{
+		{
+			Name: "valid",
+			Packet: RawPacket([]byte{
+				// v=2, p=0, count=1, BYE, len=12
+				0x81, 0xcb, 0x00, 0x0c,
+				// ssrc=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// len=3, text=FOO
+				0x03, 0x46, 0x4f, 0x4f,
+			}),
+		},
+		{
+			Name:               "short header",
+			Packet:             RawPacket([]byte{0x00}),
+			WantUnmarshalError: errPacketTooShort,
+		},
+		{
+			Name: "invalid header",
+			Packet: RawPacket([]byte{
+				// v=0, p=0, count=0, RR, len=4
+				0x00, 0xc9, 0x00, 0x04,
+			}),
+			WantUnmarshalError: errBadVersion,
+		},
+	} {
+		data, err := test.Packet.Marshal()
+		if got, want := err, test.WantMarshalError; got != want {
+			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		var decoded RawPacket
+		err = decoded.Unmarshal(data)
+		if got, want := err, test.WantUnmarshalError; got != want {
+			t.Fatalf("Unmarshal %q: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		if got, want := decoded, test.Packet; !reflect.DeepEqual(got, want) {
+			t.Fatalf("%q raw round trip: got %#v, want %#v", test.Name, got, want)
+		}
+	}
+}

--- a/internal/rtcp/receiver_report.go
+++ b/internal/rtcp/receiver_report.go
@@ -1,0 +1,213 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// A ReceiverReport (RR) packet provides reception quality feedback for an RTP stream
+type ReceiverReport struct {
+	// The synchronization source identifier for the originator of this RR packet.
+	SSRC uint32
+	// Zero or more reception report blocks depending on the number of other
+	// sources heard by this sender since the last report. Each reception report
+	// block conveys statistics on the reception of RTP packets from a
+	// single synchronization source.
+	Reports []ReceptionReport
+	// extra data from the end of the packet; the application can parse this if needed.
+	ProfileExtensions []byte
+}
+
+const (
+	ssrcLength     = 4
+	rrSSRCOffset   = headerLength
+	rrReportOffset = rrSSRCOffset + ssrcLength
+)
+
+// Marshal encodes the ReceiverReport in binary
+func (r ReceiverReport) Marshal() ([]byte, error) {
+	/*
+	 *         0                   1                   2                   3
+	 *         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * header |V=2|P|    RC   |   PT=RR=201   |             length            |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                     SSRC of packet sender                     |
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * report |                 SSRC_1 (SSRC of first source)                 |
+	 * block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *   1    | fraction lost |       cumulative number of packets lost       |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |           extended highest sequence number received           |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                      interarrival jitter                      |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                         last SR (LSR)                         |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                   delay since last SR (DLSR)                  |
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * report |                 SSRC_2 (SSRC of second source)                |
+	 * block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *   2    :                               ...                             :
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 *        |                  profile-specific extensions                  |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 */
+
+	rawPacket := make([]byte, r.len())
+	packetBody := rawPacket[headerLength:]
+
+	binary.BigEndian.PutUint32(packetBody, r.SSRC)
+
+	for i, rp := range r.Reports {
+		data, err := rp.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		offset := ssrcLength + receptionReportLength*i
+		copy(packetBody[offset:], data)
+	}
+
+	if len(r.Reports) > countMax {
+		return nil, errTooManyReports
+	}
+
+	pe := make([]byte, len(r.ProfileExtensions))
+	copy(pe, r.ProfileExtensions)
+
+	//if the length of the profile extensions isn't devisible
+	//by 4, we need to pad the end.
+	for (len(pe) & 0x3) != 0 {
+		pe = append(pe, 0)
+	}
+
+	rawPacket = append(rawPacket, pe...)
+
+	hData, err := r.Header().Marshal()
+
+	if err != nil {
+		return nil, err
+	}
+	copy(rawPacket, hData)
+
+	return rawPacket, nil
+}
+
+// Unmarshal decodes the ReceiverReport from binary
+func (r *ReceiverReport) Unmarshal(rawPacket []byte) error {
+	/*
+	 *         0                   1                   2                   3
+	 *         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * header |V=2|P|    RC   |   PT=RR=201   |             length            |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                     SSRC of packet sender                     |
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * report |                 SSRC_1 (SSRC of first source)                 |
+	 * block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *   1    | fraction lost |       cumulative number of packets lost       |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |           extended highest sequence number received           |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                      interarrival jitter                      |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                         last SR (LSR)                         |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *        |                   delay since last SR (DLSR)                  |
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * report |                 SSRC_2 (SSRC of second source)                |
+	 * block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *   2    :                               ...                             :
+	 *        +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 *        |                  profile-specific extensions                  |
+	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 */
+
+	if len(rawPacket) < (headerLength + ssrcLength) {
+		return errPacketTooShort
+	}
+
+	var h Header
+	if err := h.Unmarshal(rawPacket); err != nil {
+		return err
+	}
+
+	if h.Type != TypeReceiverReport {
+		return errWrongType
+	}
+
+	r.SSRC = binary.BigEndian.Uint32(rawPacket[rrSSRCOffset:])
+
+	for i := rrReportOffset; i < len(rawPacket) && len(r.Reports) < int(h.Count); i += receptionReportLength {
+		var rr ReceptionReport
+		if err := rr.Unmarshal(rawPacket[i:]); err != nil {
+			return err
+		}
+		r.Reports = append(r.Reports, rr)
+	}
+	r.ProfileExtensions = rawPacket[rrReportOffset+(len(r.Reports)*receptionReportLength):]
+
+	if uint8(len(r.Reports)) != h.Count {
+		return errInvalidHeader
+	}
+
+	return nil
+}
+
+func (r *ReceiverReport) len() int {
+	repsLength := 0
+	for _, rep := range r.Reports {
+		repsLength += rep.len()
+	}
+	return headerLength + ssrcLength + repsLength
+}
+
+// Header returns the Header associated with this packet.
+func (r *ReceiverReport) Header() Header {
+	return Header{
+		Count:  uint8(len(r.Reports)),
+		Type:   TypeReceiverReport,
+		Length: uint16((r.len()/4)-1) + uint16(getPadding(len(r.ProfileExtensions))),
+	}
+}
+
+// DestinationSSRC returns an array of SSRC values that this packet refers to.
+func (r *ReceiverReport) DestinationSSRC() []uint32 {
+	out := make([]uint32, len(r.Reports))
+	for i, v := range r.Reports {
+		out[i] = v.SSRC
+	}
+	return out
+}
+
+func (r ReceiverReport) String() string {
+	out := fmt.Sprintf("ReceiverReport from %x\n", r.SSRC)
+	out += fmt.Sprintf("\tSSRC    \tLost\tLastSequence\n")
+	for _, i := range r.Reports {
+		out += fmt.Sprintf("\t%x\t%d/%d\t%d\n", i.SSRC, i.FractionLost, i.TotalLost, i.LastSequenceNumber)
+	}
+	out += fmt.Sprintf("\tProfile Extension Data: %v\n", r.ProfileExtensions)
+	return out
+}

--- a/internal/rtcp/reception_report.go
+++ b/internal/rtcp/reception_report.go
@@ -1,0 +1,152 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+import "encoding/binary"
+
+// A ReceptionReport block conveys statistics on the reception of RTP packets
+// from a single synchronization source.
+type ReceptionReport struct {
+	// The SSRC identifier of the source to which the information in this
+	// reception report block pertains.
+	SSRC uint32
+	// The fraction of RTP data packets from source SSRC lost since the
+	// previous SR or RR packet was sent, expressed as a fixed point
+	// number with the binary point at the left edge of the field.
+	FractionLost uint8
+	// The total number of RTP data packets from source SSRC that have
+	// been lost since the beginning of reception.
+	TotalLost uint32
+	// The low 16 bits contain the highest sequence number received in an
+	// RTP data packet from source SSRC, and the most significant 16
+	// bits extend that sequence number with the corresponding count of
+	// sequence number cycles.
+	LastSequenceNumber uint32
+	// An estimate of the statistical variance of the RTP data packet
+	// interarrival time, measured in timestamp units and expressed as an
+	// unsigned integer.
+	Jitter uint32
+	// The middle 32 bits out of 64 in the NTP timestamp received as part of
+	// the most recent RTCP sender report (SR) packet from source SSRC. If no
+	// SR has been received yet, the field is set to zero.
+	LastSenderReport uint32
+	// The delay, expressed in units of 1/65536 seconds, between receiving the
+	// last SR packet from source SSRC and sending this reception report block.
+	// If no SR packet has been received yet from SSRC, the field is set to zero.
+	Delay uint32
+}
+
+var (
+	receptionReportLength = 24
+	fractionLostOffset    = 4
+	totalLostOffset       = 5
+	lastSeqOffset         = 8
+	jitterOffset          = 12
+	lastSROffset          = 16
+	delayOffset           = 20
+)
+
+// Marshal encodes the ReceptionReport in binary
+func (r ReceptionReport) Marshal() ([]byte, error) {
+	/*
+	 *  0                   1                   2                   3
+	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * |                              SSRC                             |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * | fraction lost |       cumulative number of packets lost       |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |           extended highest sequence number received           |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                      interarrival jitter                      |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                         last SR (LSR)                         |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                   delay since last SR (DLSR)                  |
+	 * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 */
+
+	rawPacket := make([]byte, receptionReportLength)
+
+	binary.BigEndian.PutUint32(rawPacket, r.SSRC)
+
+	rawPacket[fractionLostOffset] = r.FractionLost
+
+	// pack TotalLost into 24 bits
+	if r.TotalLost >= (1 << 25) {
+		return nil, errInvalidTotalLost
+	}
+	tlBytes := rawPacket[totalLostOffset:]
+	tlBytes[0] = byte(r.TotalLost >> 16)
+	tlBytes[1] = byte(r.TotalLost >> 8)
+	tlBytes[2] = byte(r.TotalLost)
+
+	binary.BigEndian.PutUint32(rawPacket[lastSeqOffset:], r.LastSequenceNumber)
+	binary.BigEndian.PutUint32(rawPacket[jitterOffset:], r.Jitter)
+	binary.BigEndian.PutUint32(rawPacket[lastSROffset:], r.LastSenderReport)
+	binary.BigEndian.PutUint32(rawPacket[delayOffset:], r.Delay)
+
+	return rawPacket, nil
+}
+
+// Unmarshal decodes the ReceptionReport from binary
+func (r *ReceptionReport) Unmarshal(rawPacket []byte) error {
+	if len(rawPacket) < receptionReportLength {
+		return errPacketTooShort
+	}
+
+	/*
+	 *  0                   1                   2                   3
+	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 * |                              SSRC                             |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * | fraction lost |       cumulative number of packets lost       |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |           extended highest sequence number received           |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                      interarrival jitter                      |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                         last SR (LSR)                         |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                   delay since last SR (DLSR)                  |
+	 * +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+	 */
+
+	r.SSRC = binary.BigEndian.Uint32(rawPacket)
+	r.FractionLost = rawPacket[fractionLostOffset]
+
+	tlBytes := rawPacket[totalLostOffset:]
+	r.TotalLost = uint32(tlBytes[2]) | uint32(tlBytes[1])<<8 | uint32(tlBytes[0])<<16
+
+	r.LastSequenceNumber = binary.BigEndian.Uint32(rawPacket[lastSeqOffset:])
+	r.Jitter = binary.BigEndian.Uint32(rawPacket[jitterOffset:])
+	r.LastSenderReport = binary.BigEndian.Uint32(rawPacket[lastSROffset:])
+	r.Delay = binary.BigEndian.Uint32(rawPacket[delayOffset:])
+
+	return nil
+}
+
+func (r *ReceptionReport) len() int {
+	return receptionReportLength
+}

--- a/internal/rtcp/util.go
+++ b/internal/rtcp/util.go
@@ -1,0 +1,31 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package rtcp
+
+// getPadding Returns the padding required to make the length a multiple of 4
+func getPadding(len int) int {
+	if (len &^ 3) == 0 {
+		return 0
+	}
+	return 4 - (len &^ 3)
+}

--- a/internal/srtp/srtcp.go
+++ b/internal/srtp/srtcp.go
@@ -1,0 +1,72 @@
+// MIT License
+//
+// Copyright (c) 2018 Pions
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Modification and extensions:
+// Copyright (c) 2019 Lanikai Labs. All rights reserved.
+
+package srtp
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+	"errors"
+)
+
+// See https://tools.ietf.org/html/rfc3711#section-3.4 for SRTCP packet struct
+// see https://tools.ietf.org/html/rfc3711#section-4.1.1 for AES CTR details
+func (c *Context) DecipherRTCP(deciphered, enciphered []byte) ([]byte, error) {
+	if len(enciphered) < 8+authTagSize+srtcpIndexSize {
+		return nil, errors.New("srtcp packet too short")
+	}
+
+	// Allocation optimization
+	out := allocateIfMismatch(deciphered, enciphered)
+
+	// Compute offset of packet tail
+	tailOffset := len(enciphered) - (authTagSize + srtcpIndexSize)
+	out = out[0:tailOffset]
+
+	// Check whether enciphered
+	if isEnciphered := enciphered[tailOffset] >> 7; isEnciphered == 0 {
+		return out, nil
+	}
+
+	// Index is an up-counter. Each packet is one more than the last.
+	index := binary.BigEndian.Uint32(enciphered[tailOffset:]) & 0x7fffffff
+
+	// Source identifier
+	ssrc := binary.BigEndian.Uint32(out[4:])
+
+	// Decipher in-place
+	stream := cipher.NewCTR(
+		c.srtcpBlock,
+		c.generateCounter(
+			uint16(index&0xffff),
+			index>>16,
+			ssrc,
+			c.srtcpSessionSalt,
+		),
+	)
+	stream.XORKeyStream(out[8:], out[8:])
+
+	return out, nil
+}

--- a/internal/srtp/util.go
+++ b/internal/srtp/util.go
@@ -1,0 +1,22 @@
+package srtp
+
+import "bytes"
+
+// Check if buffers match, if not allocate a new buffer and return it
+func allocateIfMismatch(dst, src []byte) []byte {
+	if dst == nil {
+		dst = make([]byte, len(src))
+		copy(dst, src)
+	} else if !bytes.Equal(dst, src) { // bytes.Equal returns on ref equality, no optimization needed
+		extraNeeded := len(src) - len(dst)
+		if extraNeeded > 0 {
+			dst = append(dst, make([]byte, extraNeeded)...)
+		} else if extraNeeded < 0 {
+			dst = dst[:len(dst)+extraNeeded]
+		}
+
+		copy(dst, src)
+	}
+
+	return dst
+}

--- a/srtcp_reader.go
+++ b/srtcp_reader.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Lanikai Labs. All rights reserved.
+
+package alohartc
+
+import (
+	"github.com/lanikai/alohartc/internal/mux"
+	"github.com/lanikai/alohartc/internal/rtcp"
+	"github.com/lanikai/alohartc/internal/srtp"
+)
+
+// srtcpReaderRunloop handles incoming SRTCP packets, namely reception reports.
+// Expected to run as a separate goroutine. Exits when the mux is closed.
+func srtcpReaderRunloop(m *mux.Mux, key, salt []byte) error {
+	buffer := make([]byte, maxSRTCPSize)
+
+	// Create new endpoint for SRTCP packets
+	endpoint := m.NewEndpoint(mux.MatchSRTCP)
+	defer endpoint.Close()
+
+	// Create cipher context
+	ctx, err := srtp.CreateContext(key, salt)
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Blocks on reading packet from endpoint
+		if n, err := endpoint.Read(buffer); err != nil {
+			return err // Endpoint closed. Exit loop.
+		} else {
+			rawPacket := buffer[:n]
+
+			// Decipher in-place
+			if _, err := ctx.DecipherRTCP(rawPacket, rawPacket); err != nil {
+				log.Error(err.Error()) // Error deciphering. Skip.
+				continue
+			}
+
+			// Parse
+			if packet, _, err := rtcp.Unmarshal(rawPacket); err != nil {
+				log.Error(err.Error()) // Malformed packet
+				continue
+			} else {
+				switch p := packet.(type) {
+				case *rtcp.ReceiverReport:
+					log.Debug(p.String()) // Print packet, for now
+				default:
+					break
+				}
+			}
+		}
+	}
+
+	return nil // Should never get here
+}


### PR DESCRIPTION
Currently, only log to debug. To enable, use `LOGLEVEL=alohartc=debug`. For our release, we'll want to aggregate the packets (per session?) and send this to Oahu, at least logging the data for our benefit.

Only the 'receiver report' type is currently handled. Will add support for other types later, some types don't make sense to add now (e.g. 'sender report' as we send no tracks currently). Most immediately, we'll want to add PLI and SLI support (i.e. picture and slice loss indicators for granular H.264 metrics).

Closed #51 