### PR TITLE
Add `get` and `generate` Makefile targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-alohacam-*
+/alohacam
 *.swp
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 CGO_ENABLED ?= 0
 GOARM ?= 7
-GOARCH ?= "arm"
-GOOS ?= "linux"
+GOARCH ?= arm
+GOOS ?= linux
+
+# Allow setting additional go build flags, e.g. `make GOFLAGS=-tags=dev`
+export GOFLAGS ?=
 
 GIT_REVISION_ID := $(shell git describe --always --dirty)
 BUILD_DATE := $(shell date)
@@ -10,15 +13,17 @@ all: examples
 
 examples: alohacam
 
-alohacam:
-	cd examples/alohacam && go generate
+alohacam: generate
 	CGO_ENABLED=$(CGO_ENABLED) GOARM=$(GOARM) GOARCH=$(GOARCH) GOOS=$(GOOS) \
 		go build -ldflags '-s -w -X main.GitRevisionId=$(GIT_REVISION_ID) -X "main.BuildDate=$(BUILD_DATE)"' \
 			-v -o alohacam \
-			examples/alohacam/handlers.go \
-			examples/alohacam/main.go \
-			examples/alohacam/statics.go \
-			examples/alohacam/templates.go
+			./examples/alohacam
+
+generate:
+	go generate -x ./...
+
+get:
+	go get -d -v ./...
 
 
-.PHONY: alohacam examples
+.PHONY: alohacam examples generate get

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Set a pre-commit hook to `go fmt` code (see https://tip.golang.org/misc/git/pre-
 
 ## Building
 
+First, download dependencies:
+
+    make get
+
 To cross-compile for a Raspberry Pi Model 3B/3B+ (armv7-based architecture):
 
     make
@@ -25,8 +29,8 @@ To cross-compile for a Raspberry Pi Zero (armv6-based architecture):
 
 ## Quickstart
 
-Build code as above, then transfer `examples/demo/demo` to Raspberry Pi and run.
-Open http://<target>:8000 in browser. This should start a live video stream from
+Build code as above, then transfer `alohacam` to Raspberry Pi and run. Open
+http://<target>:8000 in browser. This should start a live video stream from
 Raspberry Pi.
     
     


### PR DESCRIPTION
This makes it easier to get going in a new dev environment, and avoids
the `go generate` step on every build.