### PR TITLE
Implement triggered connectivity checks.

### DIFF
--- a/internal/ice/agent.go
+++ b/internal/ice/agent.go
@@ -216,7 +216,7 @@ func (a *Agent) loop(base *Base) {
 				log.Fatal("Failed to connect to remote peer")
 			}
 
-		// Periodic check
+		// [RFC8445 §6.1.4.2] Periodic connectivity check
 		case <-Ta.C:
 			if p := a.checklist.nextPair(); p != nil {
 				log.Debug("Next candidate pair to check: %s\n", p)
@@ -228,8 +228,6 @@ func (a *Agent) loop(base *Base) {
 					log.Warn("Failed to send connectivity check: %s", err)
 				}
 			}
-
-		// TODO: Triggered checks
 
 		// Keep-alive
 		case <-Tr.C:
@@ -275,10 +273,10 @@ func (a *Agent) handleStunRequest(req *stunMessage, raddr net.Addr, base *Base) 
 	}
 
 	resp := newStunBindingResponse(req.transactionID, raddr, a.localPassword)
-	log.Debug("Response %s -> %s: %s\n", base.LocalAddr(), raddr, resp)
+	log.Debug("Sending response %s -> %s: %s\n", base.LocalAddr(), raddr, resp)
 	if err := base.sendStun(resp, raddr, nil); err != nil {
 		log.Warn("Failed to send STUN response: %s", err)
 	}
 
-	// TODO: Enqueue triggered check
+	a.checklist.triggerCheck(p)
 }

--- a/internal/ice/stun.go
+++ b/internal/ice/stun.go
@@ -100,7 +100,7 @@ func (msg *stunMessage) String() string {
 		case stunAttrIceControlling:
 			fmt.Fprintf(b, ", ICE-CONTROLLING")
 		case stunAttrPriority:
-			fmt.Fprintf(b, ", PRIORITY ?")
+			fmt.Fprintf(b, ", PRIORITY %v", binary.BigEndian.Uint32(attr.Value))
 		case stunAttrSoftware:
 		case stunAttrFingerprint:
 		case stunAttrMessageIntegrity:


### PR DESCRIPTION
Triggered checks are intended to circumvent the normal ordering of
connectivity checks, such that if our ICE agent receives a connectivity
check from the remote peer, it immediately tries to send its own along
the same network path. This isn't necessary for ICE to function
properly, but it's a nice optimization. See
https://tools.ietf.org/html/rfc8445#section-6.1.4

This fixes #73 (peer reflexive candidates getting pruned) in a
roundabout way. Since the peer reflexive candidate pair gets added to
the triggered check queue, it still exists in memory even though it gets
pruned from the checklist. So if the triggered check succeeds, the pair
will be added to the valid list, and can therefore be selected even though
it was pruned. Not very elegant, but it works.

Also remove default case when writing to the checklist listener
channels. Otherwise I noticed that sometimes the checklist update would
be missed.