### PR TITLE
Make unsupported STUN methods non-fatal

### DIFF
--- a/internal/ice/agent.go
+++ b/internal/ice/agent.go
@@ -134,8 +134,13 @@ func (a *Agent) addLocalCandidate(c Candidate) {
 }
 
 func (a *Agent) handleStun(msg *stunMessage, raddr net.Addr, base *Base) {
-	if msg.method != stunBindingMethod {
-		log.Fatalf("Unexpected STUN message: %s", msg)
+	allowedMethods := map[uint16]bool{
+		stunBindingMethod: true,
+		stunSendMethod:    true,
+	}
+	if !allowedMethods[msg.method] {
+		log.Debug("Unexpected STUN message: %s", msg)
+		return
 	}
 
 	switch msg.class {

--- a/internal/ice/stun.go
+++ b/internal/ice/stun.go
@@ -116,7 +116,16 @@ const (
 	stunErrorResponse   = 3
 )
 
-const stunBindingMethod = 0x1
+const (
+	// 0, 2, and 5 are reserved
+	stunBindingMethod          = 1
+	stunAllocateMethod         = 3
+	stunRefreshMethod          = 4
+	stunSendMethod             = 6
+	stunDataMethod             = 7
+	stunCreatePermissionMethod = 8
+	stunChannelBindMethod      = 9
+)
 
 const stunHeaderLength = 20
 const stunMagicCookie = 0x2112A442


### PR DESCRIPTION
Unsupported STUN methods, such as the Send method (method 6)
introduced by TURN and sent by TURN relays, should not be
fatal.

In particular, TURN relays send a STUN binding indication via
the Send method to enable clients to authenticate the relay.
The indication does not require a reply, and does not even need
to be handled to be able to send video via the relay, but it
must not terminate the program.

Fixes #90 