### PR TITLE
Use payload type with correct packetization mode

### DIFF
--- a/internal/sdp/format_parameters.go
+++ b/internal/sdp/format_parameters.go
@@ -1,3 +1,5 @@
+// Copyright 2019 Lanikai Labs LLC. All rights reserved.
+
 package sdp
 
 import (
@@ -16,7 +18,7 @@ type H264FormatParameters struct {
 // Marshal format parameters to string
 func (fmtp *H264FormatParameters) Marshal() string {
 	format := []string{
-		fmt.Sprintf("profile-level-id=%03x", fmtp.ProfileLevelID),
+		fmt.Sprintf("profile-level-id=%06x", fmtp.ProfileLevelID),
 	}
 
 	if fmtp.LevelAsymmetryAllowed {
@@ -62,7 +64,7 @@ func (fmtp *H264FormatParameters) Unmarshal(format string) error {
 				return errMalformedFormatParameters
 			}
 		case "profile-level-id":
-			if _, err := fmt.Sscanf(pieces[1], "%03x", &fmtp.ProfileLevelID); err != nil {
+			if _, err := fmt.Sscanf(pieces[1], "%06x", &fmtp.ProfileLevelID); err != nil {
 				return errMalformedFormatParameters
 			}
 		}


### PR DESCRIPTION
As of Firefox 68.0, the RTP payload type with the correct
packetization-mode format parameter must be used.

I went back and forth a bit between a simple hack (check for `packetization-mode=1` instead of `H264/90000`, as only H.264 uses packetization-modes as far as I'm aware) or more thorough checking. Opted for the latter, although this will somewhat churn with the introduction of audio.

Fixes #95 