### PR TITLE
Fix last-packet-in-frame computation

### DIFF
--- a/internal/srtp/srtp.go
+++ b/internal/srtp/srtp.go
@@ -136,7 +136,7 @@ func (c *Conn) Send(b []byte) error {
 		mark := false
 		for i := 1; i < len(b); i += maxSize {
 			tail := i + maxSize
-			if tail > len(b) {
+			if tail >= len(b) {
 				end = 0x40
 				tail = len(b)
 			}


### PR DESCRIPTION
The RTP marker bit must be set for the last packet of a frame.
This computation had an off-by-one error.

Fixes #98 