### PR TITLE
Fix local candidate priority assignment

### DIFF
--- a/internal/ice/agent.go
+++ b/internal/ice/agent.go
@@ -50,6 +50,10 @@ func (a *Agent) Configure(mid, username, localPassword, remotePassword string) {
 	a.checklist.username = username
 	a.checklist.localPassword = localPassword
 	a.checklist.remotePassword = remotePassword
+	a.checklist.priorityTable = &PriorityTable{
+		ipv4: 65534, // evens
+		ipv6: 65535, // odds; slightly higher initial local preference for IPv6
+	}
 }
 
 func (a *Agent) Start(ctx context.Context, rcand <-chan Candidate) <-chan Candidate {
@@ -80,7 +84,7 @@ func (a *Agent) connect(ctx context.Context, rcand <-chan Candidate, lcand chan<
 	// Gather local candidates for each base.
 	go func() {
 		defer close(lcand)
-		gatherAllCandidates(ctx, bases, func(c Candidate) {
+		gatherAllCandidates(ctx, a.checklist.priorityTable, bases, func(c Candidate) {
 			a.addLocalCandidate(c)
 			select {
 			case lcand <- c:


### PR DESCRIPTION
In multi-homed or dual-stack (i.e. both IPv4 and IPv6) configurations,
local candidates must use unique local preferences for the same
candidate type preference and component ID. Otherwise, the controlling
and controlled agent could pick different candidates.

This commit uses a simple interleaved down-counter, starting the
local preference at 65534 for IPv4 and 65535 for IPv6, decrementing
each by two per local candidate.

Fixes #102 